### PR TITLE
memory corruption bug fix

### DIFF
--- a/src/gradientMex.cpp
+++ b/src/gradientMex.cpp
@@ -285,7 +285,7 @@ void hog( float *M, float *O, float *H, int h, int w, int binSize,
 {
   float *N, *R; const int hb=h/binSize, wb=w/binSize, nb=hb*wb;
   // compute unnormalized gradient histograms
-  R = (float*) wrCalloc(wb*hb*nOrients,sizeof(float));
+  R = (float*) wrCalloc(wb*hb*nOrients+2,sizeof(float));
   gradHist( M, O, R, h, w, binSize, nOrients, softBin, full );
   // compute block normalization values
   N = hogNormMatrix( R, nOrients, hb, wb, binSize );
@@ -301,7 +301,7 @@ void fhog( float *M, float *O, float *H, int h, int w, int binSize,
   const int hb=h/binSize, wb=w/binSize, nb=hb*wb, nbo=nb*nOrients;
   float *N, *R1, *R2; int o, x;
   // compute unnormalized constrast sensitive histograms
-  R1 = (float*) wrCalloc(wb*hb*nOrients*2,sizeof(float));
+  R1 = (float*) wrCalloc(wb*hb*nOrients*2+2,sizeof(float));
   gradHist( M, O, R1, h, w, binSize, nOrients*2, softBin, true );
   // compute unnormalized contrast insensitive histograms
   R2 = (float*) wrCalloc(wb*hb*nOrients,sizeof(float));


### PR DESCRIPTION
 Line 203 204, 
When xb0,yb0,O0[y] reaches the max value, sse::LDu sse::STRu instruction will read or write 1 or two 32 bit invalid memory address.
I found the problem in [another repository](https://github.com/xuduo35/STAPLE/blob/master/src/fhog.cpp) refers the same code.
The context can be recover with valgrind:

> 
==12025==   Invalid read of size 16
==12025==    at 0x41B456: _mm_loadu_ps (xmmintrin.h:905)
==12025==    by 0x41B456: LDu (sse.hpp:20)
==12025==    by 0x41B456: gradHist(float*, float*, float*, int, int, int, int, int, bool) (fhog.cpp:223)
==12025==    by 0x41C0C7: fhog(float*, float*, float*, int, int, int, int, int, float) (fhog.cpp:325)
==12025==    by 0x41C487: fhog(float*, float*, int, int, int, int*, int*, int*, int, int, float, bool) (fhog.cpp:460)
==12025==    by 0x41D17A: fhog28(cv::Mat&, cv::Mat const&, int, int, float, bool) (fhog.cpp:554)
==12025==    by 0x40D72D: STAPLE_TRACKER::getFeatureMap(cv::Mat&, char const*, cv::Mat&) (staple_tracker.cpp:528)
==12025==    by 0x414D2E: STAPLE_TRACKER::tracker_staple_train(cv::Mat const&, bool) (staple_tracker.cpp:718)
==12025==    by 0x40AD85: main (main.cpp:58)
==12025==  Address 0x14ffa4f4 is 73,716 bytes inside a block of size 73,728 alloc'd
==12025==    at 0x4C2B9B5: calloc (vg_replace_malloc.c:711)
==12025==    by 0x41C088: wrCalloc (fhog.h:36)
==12025==    by 0x41C088: fhog(float*, float*, float*, int, int, int, int, int, float) (fhog.cpp:324)
==12025==    by 0x41C487: fhog(float*, float*, int, int, int, int*, int*, int*, int, int, float, bool) (fhog.cpp:460)
==12025==    by 0x41D17A: fhog28(cv::Mat&, cv::Mat const&, int, int, float, bool) (fhog.cpp:554)
==12025==    by 0x40D72D: STAPLE_TRACKER::getFeatureMap(cv::Mat&, char const*, cv::Mat&) (staple_tracker.cpp:528)
==12025==    by 0x414D2E: STAPLE_TRACKER::tracker_staple_train(cv::Mat const&, bool) (staple_tracker.cpp:718)
==12025==    by 0x40AD85: main (main.cpp:58)
==12025==
==12025== Invalid write of size 8
==12025==    at 0x41B467: _mm_storeu_ps (xmmintrin.h:954)
==12025==    by 0x41B467: STRu (sse.hpp:23)
==12025==    by 0x41B467: gradHist(float*, float*, float*, int, int, int, int, int, bool) (fhog.cpp:223)
==12025==    by 0x41C0C7: fhog(float*, float*, float*, int, int, int, int, int, float) (fhog.cpp:325)
==12025==    by 0x41C487: fhog(float*, float*, int, int, int, int*, int*, int*, int, int, float, bool) 